### PR TITLE
Header fix + Replaced tp location direct link

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,7 +76,251 @@ Depending on if you have the full version of Content Manager or not, there are t
 
 ## Where can I find teleport locations for SRP?
 
-Either use the [official SRP teleports](<https://raw.githubusercontent.com/C1XTZ/AssettoServer-CommunityReleases/main/Shutoko%20Revival%20Project/Teleport%20Locations/Shutoko%20Revival%20Project%20(Official).txt>) or make some yourself.
+Either use the official SRP teleports below or make some yourself.
+
+<details>
+<summary>Official Shutoko Revival Project Teleport locations</summary>
+<p>
+
+```ini
+[TELEPORT_DESTINATIONS]
+POINT_1 = Position 1
+POINT_1_GROUP = Shibaura PA
+POINT_1_POS = 1098.82, 25.28, -4642.14
+POINT_1_HEADING = 246
+
+POINT_2 = Position 2
+POINT_2_GROUP = Shibaura PA
+POINT_2_POS = 1098.77, 25.28, -4649.76
+POINT_2_HEADING = 245
+
+POINT_3 = Position 3
+POINT_3_GROUP = Shibaura PA
+POINT_3_POS = 1098.9, 25.28, -4657.39
+POINT_3_HEADING = 246
+
+POINT_4 = Position 4
+POINT_4_GROUP = Shibaura PA
+POINT_4_POS = 1099.37, 25.31, -4664.88
+POINT_4_HEADING = 246
+
+POINT_5 = Position 5
+POINT_5_GROUP = Shibaura PA
+POINT_5_POS = 1099.15, 25.31, -4672.42
+POINT_5_HEADING = 245
+
+POINT_6 = Position 1
+POINT_6_GROUP = Tatsumi PA
+POINT_6_POS = 5862.09, 23.31, -4648.95
+POINT_6_HEADING = 267
+
+POINT_7 = Position 2
+POINT_7_GROUP = Tatsumi PA
+POINT_7_POS = 5850.9, 22.89, -4644.56
+POINT_7_HEADING = 268
+
+POINT_8 = Position 3
+POINT_8_GROUP = Tatsumi PA
+POINT_8_POS = 5839.74, 22.47, -4640.04
+POINT_8_HEADING = 268
+
+POINT_9 = Position 1
+POINT_9_GROUP = Daishi PA
+POINT_9_POS = -308.59, 15.49, 6143.8
+POINT_9_HEADING = 68
+
+POINT_10 = Position 2
+POINT_10_GROUP = Daishi PA
+POINT_10_POS = -308.48, 15.47, 6150.66
+POINT_10_HEADING = 68
+
+POINT_11 = Position 3
+POINT_11_GROUP = Daishi PA
+POINT_11_POS = -308.13, 15.44, 6157.93
+POINT_11_HEADING = 66
+
+POINT_12 = Position 1
+POINT_12_GROUP = Heiwajima PA North
+POINT_12_POS = -230.06, 12.3, 1360.02
+POINT_12_HEADING = 104
+
+POINT_13 = Position 2
+POINT_13_GROUP = Heiwajima PA North
+POINT_13_POS = -234.92, 12.3, 1354.07
+POINT_13_HEADING = 106
+
+POINT_14 = Position 3
+POINT_14_GROUP = Heiwajima PA North
+POINT_14_POS = -239.82, 12.3, 1348.12
+POINT_14_HEADING = 105
+
+POINT_15 = Position 1
+POINT_15_GROUP = Oi PA
+POINT_15_POS = 964.93, 6.7, -126.06
+POINT_15_HEADING = 156
+
+POINT_16 = Position 2
+POINT_16_GROUP = Oi PA
+POINT_16_POS = 964.9, 6.75, -138.0
+POINT_16_HEADING = 156
+
+POINT_17 = Position 3
+POINT_17_GROUP = Oi PA
+POINT_17_POS = 964.82, 6.8, -151.17
+POINT_17_HEADING = 156
+
+POINT_18 = Position 1
+POINT_18_GROUP = Mirai - Kinko JCT
+POINT_18_POS = -10854.32, 11.96, 13422.77
+POINT_18_HEADING = 287
+
+POINT_19 = Position 2
+POINT_19_GROUP = Mirai - Kinko JCT
+POINT_19_POS = -10846.16, 11.97, 13415.76
+POINT_19_HEADING = 283
+
+POINT_20 = Position 1
+POINT_20_GROUP = Bayshore North - Kawasaki Port
+POINT_20_POS = -83.84, 7.1, 10983.11
+POINT_20_HEADING = 273
+
+POINT_21 = Position 2
+POINT_21_GROUP = Bayshore North - Kawasaki Port
+POINT_21_POS = -102.97, 7.72, 10993.15
+POINT_21_HEADING = 274
+
+POINT_24 = Position 1
+POINT_24_GROUP = C1 Outer - Edobashi JCT
+POINT_24_POS = 2512.15, 12.23, -9223.27
+POINT_24_HEADING = 231
+
+POINT_25 = Position 2
+POINT_25_GROUP = C1 Outer - Edobashi JCT
+POINT_25_POS = 2503.33, 12.02, -9225.59
+POINT_25_HEADING = 232
+
+POINT_26 = Position 1
+POINT_26_GROUP = Shinjuku Station
+POINT_26_POS = -4251.66, 32.94, -10032.48
+POINT_26_HEADING = 208
+
+POINT_27 = Position 2
+POINT_27_GROUP = Shinjuku Station
+POINT_27_POS = -4244.07, 32.94, -10016.75
+POINT_27_HEADING = 159
+
+POINT_28 = Position 3
+POINT_28_GROUP = Shinjuku Station
+POINT_28_POS = -4242.9, 32.95, -9995.6
+POINT_28_HEADING = 160
+
+POINT_29 = Position 1
+POINT_29_GROUP = Yokohama - Daikoku
+POINT_29_POS = -6147.93, 29.65, 13722.33
+POINT_29_HEADING = 346
+
+POINT_30 = Position 2
+POINT_30_GROUP = Yokohama - Daikoku
+POINT_30_POS = -6151.91, 29.71, 13702.23
+POINT_30_HEADING = 347
+
+POINT_31 = Position 1
+POINT_31_GROUP = Shibuya Station
+POINT_31_POS = -4039.77, 16.47, -6289.3
+POINT_31_HEADING = 180
+
+POINT_32 = Position 1
+POINT_32_GROUP = Shibuya Station
+POINT_32_POS = -4045.18, 16.47, -6301.12
+POINT_32_HEADING = 181
+
+POINT_33 = Position 1
+POINT_33_GROUP = Shibuya Station
+POINT_33_POS = -4053.5, 16.47, -6319.83
+POINT_33_HEADING = 180
+
+POINT_34 = Position 1
+POINT_34_GROUP = Heiwajima PA - South
+POINT_34_POS = -135.82, 6.57, 1475.1
+POINT_34_HEADING = 128
+
+POINT_35 = Position 2
+POINT_35_GROUP = Heiwajima PA - South
+POINT_35_POS = -141.18, 6.55, 1463.26
+POINT_35_HEADING = 132
+
+POINT_36 = Position 3
+POINT_36_GROUP = Heiwajima PA - South
+POINT_36_POS = -146.6, 6.48, 1451.75
+POINT_36_HEADING = 130
+
+POINT_37_GROUP = C1 Inner - Ginza
+POINT_37_POS = 2189.27, -1.7, -7551.21
+POINT_37_HEADING = 111
+
+POINT_38 = Position 2
+POINT_38_GROUP = C1 Inner - Ginza
+POINT_38_POS = 2179.76, -1.66, -7541.2
+POINT_38_HEADING = 291
+
+POINT_39 = Position 1
+POINT_39_GROUP = Bayshore North - Tamagawa River Tunnel
+POINT_39_POS = 4104.18, -7.82, 8489.0
+POINT_39_HEADING = 304
+
+POINT_40 = Position 2
+POINT_40_GROUP = Bayshore North - Tamagawa River Tunnel
+POINT_40_POS = 4121.05, -8.34, 8463.49
+POINT_40_HEADING = 303
+
+POINT_41 = Position 1
+POINT_41_GROUP = Bayshore South - Haneda Airport
+POINT_41_POS = 3278.37, 0.83, 4292.55
+POINT_41_HEADING = 197
+
+POINT_42 = Position 2
+POINT_42_GROUP = Bayshore South - Haneda Airport
+POINT_42_POS = 3265.07, 0.72, 4278.06
+POINT_42_HEADING = 199
+
+POINT_42 = Position 2
+POINT_42_GROUP = Bayshore South - Haneda Airport
+POINT_42_POS = 3265.07, 0.72, 4278.06
+POINT_42_HEADING = 199
+
+POINT_43 = Position 1
+POINT_43_GROUP = Kariba - Sakuragicho
+POINT_43_POS = -7478.14, 13.01, 16477.58
+POINT_43_HEADING = 22
+
+POINT_44 = Position 1
+POINT_44_GROUP = C1 Inner - Kitanomaru
+POINT_44_POS = 767.52, 16.46, -9914.88
+POINT_44_HEADING = 87
+
+POINT_45 = Position 2
+POINT_45_GROUP = C1 Inner - Kitanomaru
+POINT_45_POS = 782.83, 16.48, -9921.26
+POINT_45_HEADING = 89
+
+POINT_46 = Position 1
+POINT_46_GROUP = Belt Inner - Fukuzumi
+POINT_46_POS = 4522.27, 13.97, -8210.62
+POINT_46_HEADING = 350
+
+POINT_47 = Position 2
+POINT_47_GROUP = Belt Inner - Fukuzumi
+POINT_47_POS = 4524.72, 14.32, -8199.7
+POINT_47_HEADING = 349
+
+POINT_48 = Position 1
+POINT_48_GROUP = Yokohane - Kawasaki
+POINT_48_POS = -2533.62, 11.02, 8864.47
+POINT_48_HEADING = 86
+```
+
+</p>
+</details>
 
 ## How do I make my own teleport locations?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ If the file doesn't exist yet, create it yourself. For example:
 ![](./assets/oxp4a21.png)    
 Place the file in the `cfg` folder of your server. If you're running your server via Content Manager, click the `Folder` button and place it there instead.   
 
-# How do I allow driving the wrong way?
+## How do I allow driving the wrong way?
 
 ```ini
 [EXTRA_RULES]

--- a/versioned_docs/version-0.0.50/faq.md
+++ b/versioned_docs/version-0.0.50/faq.md
@@ -76,7 +76,251 @@ Depending on if you have the full version of Content Manager or not, there are t
 
 ## Where can I find teleport locations for SRP?
 
-Either use the [official SRP teleports](<https://raw.githubusercontent.com/C1XTZ/AssettoServer-CommunityReleases/main/Shutoko%20Revival%20Project/Teleport%20Locations/Shutoko%20Revival%20Project%20(Official).txt>) or make some yourself.
+Either use the official SRP teleports below or make some yourself.
+
+<details>
+<summary>Official Shutoko Revival Project Teleport locations</summary>
+<p>
+
+```ini
+[TELEPORT_DESTINATIONS]
+POINT_1 = Position 1
+POINT_1_GROUP = Shibaura PA
+POINT_1_POS = 1098.82, 25.28, -4642.14
+POINT_1_HEADING = 246
+
+POINT_2 = Position 2
+POINT_2_GROUP = Shibaura PA
+POINT_2_POS = 1098.77, 25.28, -4649.76
+POINT_2_HEADING = 245
+
+POINT_3 = Position 3
+POINT_3_GROUP = Shibaura PA
+POINT_3_POS = 1098.9, 25.28, -4657.39
+POINT_3_HEADING = 246
+
+POINT_4 = Position 4
+POINT_4_GROUP = Shibaura PA
+POINT_4_POS = 1099.37, 25.31, -4664.88
+POINT_4_HEADING = 246
+
+POINT_5 = Position 5
+POINT_5_GROUP = Shibaura PA
+POINT_5_POS = 1099.15, 25.31, -4672.42
+POINT_5_HEADING = 245
+
+POINT_6 = Position 1
+POINT_6_GROUP = Tatsumi PA
+POINT_6_POS = 5862.09, 23.31, -4648.95
+POINT_6_HEADING = 267
+
+POINT_7 = Position 2
+POINT_7_GROUP = Tatsumi PA
+POINT_7_POS = 5850.9, 22.89, -4644.56
+POINT_7_HEADING = 268
+
+POINT_8 = Position 3
+POINT_8_GROUP = Tatsumi PA
+POINT_8_POS = 5839.74, 22.47, -4640.04
+POINT_8_HEADING = 268
+
+POINT_9 = Position 1
+POINT_9_GROUP = Daishi PA
+POINT_9_POS = -308.59, 15.49, 6143.8
+POINT_9_HEADING = 68
+
+POINT_10 = Position 2
+POINT_10_GROUP = Daishi PA
+POINT_10_POS = -308.48, 15.47, 6150.66
+POINT_10_HEADING = 68
+
+POINT_11 = Position 3
+POINT_11_GROUP = Daishi PA
+POINT_11_POS = -308.13, 15.44, 6157.93
+POINT_11_HEADING = 66
+
+POINT_12 = Position 1
+POINT_12_GROUP = Heiwajima PA North
+POINT_12_POS = -230.06, 12.3, 1360.02
+POINT_12_HEADING = 104
+
+POINT_13 = Position 2
+POINT_13_GROUP = Heiwajima PA North
+POINT_13_POS = -234.92, 12.3, 1354.07
+POINT_13_HEADING = 106
+
+POINT_14 = Position 3
+POINT_14_GROUP = Heiwajima PA North
+POINT_14_POS = -239.82, 12.3, 1348.12
+POINT_14_HEADING = 105
+
+POINT_15 = Position 1
+POINT_15_GROUP = Oi PA
+POINT_15_POS = 964.93, 6.7, -126.06
+POINT_15_HEADING = 156
+
+POINT_16 = Position 2
+POINT_16_GROUP = Oi PA
+POINT_16_POS = 964.9, 6.75, -138.0
+POINT_16_HEADING = 156
+
+POINT_17 = Position 3
+POINT_17_GROUP = Oi PA
+POINT_17_POS = 964.82, 6.8, -151.17
+POINT_17_HEADING = 156
+
+POINT_18 = Position 1
+POINT_18_GROUP = Mirai - Kinko JCT
+POINT_18_POS = -10854.32, 11.96, 13422.77
+POINT_18_HEADING = 287
+
+POINT_19 = Position 2
+POINT_19_GROUP = Mirai - Kinko JCT
+POINT_19_POS = -10846.16, 11.97, 13415.76
+POINT_19_HEADING = 283
+
+POINT_20 = Position 1
+POINT_20_GROUP = Bayshore North - Kawasaki Port
+POINT_20_POS = -83.84, 7.1, 10983.11
+POINT_20_HEADING = 273
+
+POINT_21 = Position 2
+POINT_21_GROUP = Bayshore North - Kawasaki Port
+POINT_21_POS = -102.97, 7.72, 10993.15
+POINT_21_HEADING = 274
+
+POINT_24 = Position 1
+POINT_24_GROUP = C1 Outer - Edobashi JCT
+POINT_24_POS = 2512.15, 12.23, -9223.27
+POINT_24_HEADING = 231
+
+POINT_25 = Position 2
+POINT_25_GROUP = C1 Outer - Edobashi JCT
+POINT_25_POS = 2503.33, 12.02, -9225.59
+POINT_25_HEADING = 232
+
+POINT_26 = Position 1
+POINT_26_GROUP = Shinjuku Station
+POINT_26_POS = -4251.66, 32.94, -10032.48
+POINT_26_HEADING = 208
+
+POINT_27 = Position 2
+POINT_27_GROUP = Shinjuku Station
+POINT_27_POS = -4244.07, 32.94, -10016.75
+POINT_27_HEADING = 159
+
+POINT_28 = Position 3
+POINT_28_GROUP = Shinjuku Station
+POINT_28_POS = -4242.9, 32.95, -9995.6
+POINT_28_HEADING = 160
+
+POINT_29 = Position 1
+POINT_29_GROUP = Yokohama - Daikoku
+POINT_29_POS = -6147.93, 29.65, 13722.33
+POINT_29_HEADING = 346
+
+POINT_30 = Position 2
+POINT_30_GROUP = Yokohama - Daikoku
+POINT_30_POS = -6151.91, 29.71, 13702.23
+POINT_30_HEADING = 347
+
+POINT_31 = Position 1
+POINT_31_GROUP = Shibuya Station
+POINT_31_POS = -4039.77, 16.47, -6289.3
+POINT_31_HEADING = 180
+
+POINT_32 = Position 1
+POINT_32_GROUP = Shibuya Station
+POINT_32_POS = -4045.18, 16.47, -6301.12
+POINT_32_HEADING = 181
+
+POINT_33 = Position 1
+POINT_33_GROUP = Shibuya Station
+POINT_33_POS = -4053.5, 16.47, -6319.83
+POINT_33_HEADING = 180
+
+POINT_34 = Position 1
+POINT_34_GROUP = Heiwajima PA - South
+POINT_34_POS = -135.82, 6.57, 1475.1
+POINT_34_HEADING = 128
+
+POINT_35 = Position 2
+POINT_35_GROUP = Heiwajima PA - South
+POINT_35_POS = -141.18, 6.55, 1463.26
+POINT_35_HEADING = 132
+
+POINT_36 = Position 3
+POINT_36_GROUP = Heiwajima PA - South
+POINT_36_POS = -146.6, 6.48, 1451.75
+POINT_36_HEADING = 130
+
+POINT_37_GROUP = C1 Inner - Ginza
+POINT_37_POS = 2189.27, -1.7, -7551.21
+POINT_37_HEADING = 111
+
+POINT_38 = Position 2
+POINT_38_GROUP = C1 Inner - Ginza
+POINT_38_POS = 2179.76, -1.66, -7541.2
+POINT_38_HEADING = 291
+
+POINT_39 = Position 1
+POINT_39_GROUP = Bayshore North - Tamagawa River Tunnel
+POINT_39_POS = 4104.18, -7.82, 8489.0
+POINT_39_HEADING = 304
+
+POINT_40 = Position 2
+POINT_40_GROUP = Bayshore North - Tamagawa River Tunnel
+POINT_40_POS = 4121.05, -8.34, 8463.49
+POINT_40_HEADING = 303
+
+POINT_41 = Position 1
+POINT_41_GROUP = Bayshore South - Haneda Airport
+POINT_41_POS = 3278.37, 0.83, 4292.55
+POINT_41_HEADING = 197
+
+POINT_42 = Position 2
+POINT_42_GROUP = Bayshore South - Haneda Airport
+POINT_42_POS = 3265.07, 0.72, 4278.06
+POINT_42_HEADING = 199
+
+POINT_42 = Position 2
+POINT_42_GROUP = Bayshore South - Haneda Airport
+POINT_42_POS = 3265.07, 0.72, 4278.06
+POINT_42_HEADING = 199
+
+POINT_43 = Position 1
+POINT_43_GROUP = Kariba - Sakuragicho
+POINT_43_POS = -7478.14, 13.01, 16477.58
+POINT_43_HEADING = 22
+
+POINT_44 = Position 1
+POINT_44_GROUP = C1 Inner - Kitanomaru
+POINT_44_POS = 767.52, 16.46, -9914.88
+POINT_44_HEADING = 87
+
+POINT_45 = Position 2
+POINT_45_GROUP = C1 Inner - Kitanomaru
+POINT_45_POS = 782.83, 16.48, -9921.26
+POINT_45_HEADING = 89
+
+POINT_46 = Position 1
+POINT_46_GROUP = Belt Inner - Fukuzumi
+POINT_46_POS = 4522.27, 13.97, -8210.62
+POINT_46_HEADING = 350
+
+POINT_47 = Position 2
+POINT_47_GROUP = Belt Inner - Fukuzumi
+POINT_47_POS = 4524.72, 14.32, -8199.7
+POINT_47_HEADING = 349
+
+POINT_48 = Position 1
+POINT_48_GROUP = Yokohane - Kawasaki
+POINT_48_POS = -2533.62, 11.02, 8864.47
+POINT_48_HEADING = 86
+```
+
+</p>
+</details>
 
 ## How do I make my own teleport locations?
 

--- a/versioned_docs/version-0.0.50/faq.md
+++ b/versioned_docs/version-0.0.50/faq.md
@@ -19,7 +19,7 @@ If the file doesn't exist yet, create it yourself. For example:
 ![](./assets/oxp4a21.png)    
 Place the file in the `cfg` folder of your server. If you're running your server via Content Manager, click the `Folder` button and place it there instead.   
 
-# How do I allow driving the wrong way?
+## How do I allow driving the wrong way?
 
 ```ini
 [EXTRA_RULES]


### PR DESCRIPTION
I figured that having the teleports directly on the page would be a little bit cleaner than linking to them.