### PR TITLE
Added checksums to FAQ & ForceServerTrackParams to track config errors

### DIFF
--- a/docs/common-configuration-errors.md
+++ b/docs/common-configuration-errors.md
@@ -18,7 +18,7 @@ When there is no entry in this file for your map this error will be shown. This 
 
 As of CSP version 0.1.78 you can also specify timezone, as well as latitude and longitude in the `csp_extra_options.ini` directly to ensure all clients will be in the same lighting conditions. Read the CSP Wiki for more info: https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#timezone
 
-Additionally you can manually add an entry for your track in `cfg/data_track_params.ini`, **but if you enable WeatherFX in `extra_cfg.yml`, time will not be in sync between server and client, unless you add that entry to `extension/config/data_track_params.ini` in your AC folder as well.**
+Additionally you can manually add an entry for your track in `cfg/data_track_params.ini`, **but if you enable WeatherFX in `extra_cfg.yml`, time will not be in sync between server and client, unless you also enable ForceServerTrackParams.**
 
 If you want to ignore this error set this in `extra_cfg.yml`:
 ```yaml

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,6 +11,30 @@ import TabItem from '@theme/TabItem';
 - Decrease `MinAiSafetyDistanceMeters` / `MaxAiSafetyDistanceMeters` to make gaps between AI cars smaller
 - Depending on how many people are on your server you could increase `AiPerPlayerTargetCount` / `MaxAiTargetCount`
 
+## How do I remove checksums?
+
+:::caution ONLY REMOVE CHECKSUMS IF YOU'RE OKAY WITH USERS CHEATING
+Checksums are required to prevent people from cheating by modifying their car and track data. Remove them at your own risk.
+:::
+
+<Tabs>
+<TabItem value="cars" label="Car Checksums" default>
+
+  - Navigate to the `\content\cars` folder on your server.
+  - Remove the `data.acd` in the folder of every car that you want to use without checksums.
+  - Enable MissingCarChecksums in `extra_cfg.yml` and restart the server.
+  - If you've done everything correctly you should no longer see a `Added checksum for car_name` log message for the car you removed. If you've removed the checksum of all cars it should also log `Initialized 0 car checksums`.
+
+</TabItem>
+<TabItem value="tracks" label="Track Checksums">
+
+  - Navigate to the `\content\tracks\<track>\<layout>\data` (or `\content\tracks\csp\<track>\<layout>\data` if you're forcing a CSP version.) and `\system` folders on your server.
+  - Remove both of the `surfaces.ini` files and restart the server.
+  - If you've done everything correctly you should see the log message saying `Initialized 0 track checksums`
+
+</TabItem>
+</Tabs>
+
 ## How do I use CSP extra server options?
 
 Read [this CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) carefully. Everything you want to add goes into `cfg/csp_extra_options.ini`.  

--- a/versioned_docs/version-0.0.50/common-configuration-errors.md
+++ b/versioned_docs/version-0.0.50/common-configuration-errors.md
@@ -18,7 +18,7 @@ When there is no entry in this file for your map this error will be shown. This 
 
 As of CSP version 0.1.78 you can also specify timezone, as well as latitude and longitude in the `csp_extra_options.ini` directly to ensure all clients will be in the same lighting conditions. Read the CSP Wiki for more info: https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#timezone
 
-Additionally you can manually add an entry for your track in `cfg/data_track_params.ini`, **but if you enable WeatherFX in `extra_cfg.yml`, time will not be in sync between server and client, unless you add that entry to `extension/config/data_track_params.ini` in your AC folder as well.**
+Additionally you can manually add an entry for your track in `cfg/data_track_params.ini`, **but if you enable WeatherFX in `extra_cfg.yml`, time will not be in sync between server and client, unless you also enable ForceServerTrackParams.**
 
 If you want to ignore this error set this in `extra_cfg.yml`:
 ```yaml

--- a/versioned_docs/version-0.0.50/faq.md
+++ b/versioned_docs/version-0.0.50/faq.md
@@ -11,6 +11,30 @@ import TabItem from '@theme/TabItem';
 - Decrease `MinAiSafetyDistanceMeters` / `MaxAiSafetyDistanceMeters` to make gaps between AI cars smaller
 - Depending on how many people are on your server you could increase `AiPerPlayerTargetCount` / `MaxAiTargetCount`
 
+## How do I remove checksums?
+
+:::caution ONLY REMOVE CHECKSUMS IF YOU'RE OKAY WITH USERS CHEATING
+Checksums are required to prevent people from cheating by modifying their car and track data. Remove them at your own risk.
+:::
+
+<Tabs>
+<TabItem value="cars" label="Car Checksums" default>
+
+  - Navigate to the `\content\cars` folder on your server.
+  - Remove the `data.acd` in the folder of every car that you want to use without checksums.
+  - Enable MissingCarChecksums in `extra_cfg.yml` and restart the server.
+  - If you've done everything correctly you should no longer see a `Added checksum for car_name` log message for the car you removed. If you've removed the checksum of all cars it should also log `Initialized 0 car checksums`.
+
+</TabItem>
+<TabItem value="tracks" label="Track Checksums">
+
+  - Navigate to the `\content\tracks\<track>\<layout>\data` (or `\content\tracks\csp\<track>\<layout>\data` if you're forcing a CSP version.) and `\system` folders on your server.
+  - Remove both of the `surfaces.ini` files and restart the server.
+  - If you've done everything correctly you should see the log message saying `Initialized 0 track checksums`
+
+</TabItem>
+</Tabs>
+
 ## How do I use CSP extra server options?
 
 Read [this CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) carefully. Everything you want to add goes into `cfg/csp_extra_options.ini`.  


### PR DESCRIPTION
Feel free to leave out or rewrite the ForceServerTrackParams part. I think this is better than telling peple to manually edit their local files even if it requires a fairly new CSP version.