### PR TITLE
FAQ: newline fix and CSP extra option refactoring

### DIFF
--- a/docs/admin-commands.md
+++ b/docs/admin-commands.md
@@ -97,6 +97,12 @@ title: Admin Commands
 | wetness   | The track wetness.                         |
 | water     | The amount of standing water on the track. |
 
+:::note
+
+Parameters range from 0-1 meaning `/setrain 1 1 1` would set all of them to the maximum.
+
+:::
+
 ## Set track grip
 
 `/setgrip <gripValue>`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 ## Why can't I drive certain cars on my server? {#locked-cars}
 
 Certain car mods are designed to only be driven on servers that are whitelisted by the creators of the car mod.  
-Affected cars usually do not respond to the gas pedal input if they are used on other servers.
+Affected cars usually do not respond to the gas pedal input if they are used on other servers.  
 This restriction is built into the car mod itself and cannot be deactivated by any means.  
 Please note that these restrictions are not a feature of AssettoServer.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -574,8 +574,6 @@ KEEP_COLLISIONS = 0   ; Activate collisions between cars in pits
 SPEED_KMH = 80        ; Alter pits speed limiter value; default is 80
 ```
 
-[There are more options available here.](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#pit-speed-limiter-settings)
-
 ### How do I use Server Scripts? {#csp-server-scripts}
 
 :::note

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -145,19 +145,41 @@ ForceServerTrackParams: true
 
 ## How do I use CSP extra server options? {#csp-extra-options}
 
-Read [this CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) carefully. Everything you want to add goes into `cfg/csp_extra_options.ini`.  
-If the file doesn't exist yet, create it yourself. For example:
+#### Changing the required CSP version {#requiring-csp-version}
 
-![](./assets/oxp4a21.png)    
-Place the file in the `cfg` folder of your server.  
+```yaml title="extra_cfg.yml"
+# Override minimum CSP version required to join this server. Leave this empty to not require CSP.
+MinimumCSPVersion: 1937
+```
 
-:::note
+<details>
+<summary>**Where can I find CSP version IDs?**</summary>
+<p>
 
-If you're hosting the server via Content Manager, click the `Folder` button at the bottom of the preset and place it there instead.
+In Content Manager, navigate to `Settings > Custom Shaders Patch > About & Updates` and look for the Currently active Shaders Patch version ID.
 
-:::
+![](./assets/lKOfMSR.png)
+
+If you need the ID of a version you currently don't have installed **[the official CSP Website](https://acstuff.ru/patch/)** lists the IDs in the `Other Versions` sections.
+
+![](./assets/Upd4ZJl.png)
+
+</p>
+</details>
+
+#### Adding CSP extra server options to the server {#extra-options-ini}
+Navigate to the `cfg` folder of the server and create a file called `csp_extra_options.ini`.  
+If you are hosting via Content Manager, click the `Folder` button at the bottom of the preset and create the file there instead.  
+
+[This CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) has a long list of options you can use.  
+The options on that page go into the `csp_extra_options.ini`, for example:
+
+![](./assets/oxp4a21.png) 
 
 ### How do I allow driving the wrong way? {#wrong-way}
+
+This is also used to remove the incorrectly displayed wrong way indicator on track like Shutoko Revival Project.  
+If you want to make sure that people drive the correct way after adding this setting, use the [AutoModerationPlugin.](./plugins/AutoModerationPlugin.md)
 
 ```ini title="csp_extra_options.ini"
 [EXTRA_RULES]
@@ -211,7 +233,7 @@ If done correctly you should now have a `Teleport to...` option in the chat apps
 Either use the teleports used on the official SRP servers below or make some yourself.  
 
 <details>
-<summary>Official Shutoko Revival Project Teleport locations</summary>
+<summary>**Official Shutoko Revival Project Teleport locations**</summary>
 <p>Last updated: 2024-04-24</p>
 <p>
 
@@ -517,30 +539,39 @@ You can use the Objects Inspector or the [comfy map app](https://www.racedepartm
 The formating is as follows:
 
 ```ini
-POINT_0 = Name               ; destination name
-POINT_0_GROUP = Group Name   ; optional group
-POINT_0_POS = X, Y, Z        ; coordinates
-POINT_0_HEADING = 0          ; heading angle in degrees
+POINT_0 = Name               ; Destination name
+POINT_0_GROUP = Group Name   ; Optional group
+POINT_0_POS = X, Y, Z        ; Coordinates
+POINT_0_HEADING = 0          ; Heading angle in degrees
 ```
 
-**Having the comfy map app is not necessary to create points, enable or use teleportation!**
+:::note
+
+The comfy map app is not required to create points, enable or use teleportation!
+
+:::
 
 ### How do I enable Color Changing? {#color-changing}
 
 ```ini title="csp_extra_options.ini"
 [CUSTOM_COLOR]
-ALLOW_EVERYWHERE = 1
+ALLOW_EVERYWHERE = 1   ; Change car colors anywhere as long as the car is stopped.
 ```
 
 If AI cars are allowed to change their colors, they will spawn in random colors if possible.  
-**Keep in mind that you still need to allow cars to change colors via the `entry_list.ini` even if you're using `ALLOW_EVERYWHERE`.**
+
+:::caution
+
+Every car still needs to be allowed to change colors via the `entry_list.ini`.
+
+:::
 
 ### How do I increase the speed in the pits? {#pit-speed-limiter}
 
 ```ini title="csp_extra_options.ini"
 [PITS_SPEED_LIMITER]
-KEEP_COLLISIONS = 0    ; will either activate or deactivate collisions between cars in the pits.
-SPEED_KMH = 80         ; the maximum speed allowed, the default is 80.
+KEEP_COLLISIONS = 0   ; Activate collisions between cars in pits
+SPEED_KMH = 80        ; Alter pits speed limiter value; default is 80
 ```
 
 [There are more options available here.](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#pit-speed-limiter-settings)
@@ -560,7 +591,7 @@ You're going to need to host your script in plaintext somewhere publicly accessi
 
 ```ini title="csp_extra_options.ini"
 [SCRIPT_...]
-SCRIPT = "https://pastebin.com/raw/00000000000"    ; change this to the url of your script
+SCRIPT = "https://pastebin.com/raw/00000000000"    ; Change this to the url of your script
 ```
 
 [There are more options available here.](https://github.com/CheesyManiac/cheesy-lua/wiki/Extra-CSP-Server-Config-Values#server-scripts)
@@ -572,7 +603,7 @@ This can be done by either providing direct download links if the content is sto
 
 ![](./assets/HfLjm64.png)
 
-### Via 3rd party file hosting services
+### Via 3rd party file hosting services {#remote-downloads}
 
 :::caution
 
@@ -624,7 +655,7 @@ Please use the download links the authors of the content you're using provide un
 </TabItem>
 </Tabs>
 
-### Via the server directly
+### Via the server directly {#direct-downloads}
 
 <Tabs groupId="content-manager">
 <TabItem value="content-manager" label="With Content Manager (Full Version)" default>
@@ -734,13 +765,3 @@ ServerDescription: |-
   - If you dont have Sol working, or are otherwise in doubt,
     keep your lights on.
 ```
-
-## Where can I find the CSP version IDs? {#csp-version-ids}
-
-The easiest way to get the ID for the CSP Version you're using is opening Content Manager and navigating to `Settings > Custom Shaders Patch > About & Updates` and then reading the Currently active Shaders Patch version ID.
-
-![](./assets/lKOfMSR.png)
-
-If you need the ID of a version you currently don't have installed [the official CSP Website](https://acstuff.ru/patch/) also has the IDs in the `Other Versions` sections.
-
-![](./assets/Upd4ZJl.png)

--- a/docs/thebeginnersguide.md
+++ b/docs/thebeginnersguide.md
@@ -389,7 +389,7 @@ Purchase Custom Shaders Patch previews on [x4fabs Patreon](https://www.patreon.c
 
 AssettoServer requires CSP version 0.1.77 (1937) by default.  
 To change this edit `MinimumCSPVersion: 1937` in the `extra_cfg.yml`.  
-If you want to require a different CSP version and don't know how where to get the ID from, read the [FAQ section](./faq.md#csp-version-ids) that explains it.
+If you want to require a different CSP version and don't know how where to get the ID from, read this [FAQ section](./faq.md#requiring-csp-version).
 
 Navigate to the `cfg` folder of the server and create a file called `csp_extra_options.ini`.  
 The [CSP Wiki](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) has a long list of options and settings you can play around with.  

--- a/versioned_docs/version-0.0.54/faq.md
+++ b/versioned_docs/version-0.0.54/faq.md
@@ -591,8 +591,6 @@ KEEP_COLLISIONS = 0   ; Activate collisions between cars in pits
 SPEED_KMH = 80        ; Alter pits speed limiter value; default is 80
 ```
 
-[There are more options available here.](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#pit-speed-limiter-settings)
-
 ### How do I use Server Scripts? {#csp-server-scripts}
 
 :::note

--- a/versioned_docs/version-0.0.54/faq.md
+++ b/versioned_docs/version-0.0.54/faq.md
@@ -143,42 +143,79 @@ ForceServerTrackParams: true
 
 ## How do I use CSP extra server options? {#csp-extra-options}
 
-Read [this CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) carefully. Everything you want to add goes into `cfg/csp_extra_options.ini`.  
-If the file doesn't exist yet, create it yourself. For example:
+#### Requiring a minimum CSP Version {#requiring-csp-version}
+<Tabs groupId="content-manager">
+<TabItem value="content-manager" label="With Content Manager (Full Version)" default>
+
+  In the `Main` tab, enable `Require CSP to Join` and enter the desired CSP version ID or click on `Autofill` to insert the version ID of the CSP version you have currently installed:  
+  
+  ![](./assets/HxAVvsd.png)
+
+</TabItem>
+<TabItem value="manual" label="Without Content Manager">
+
+  - In `content/tracks` of your server, create a new folder called `csp`
+  - Move your track folder into `content/tracks/csp`
+  - In `server_cfg.ini` change the path of your track like this: `TRACK=csp/<CSPversionID>/../<trackname>`  
+    For example: `TRACK=csp/2053/../shuto_revival_project_beta`
+  - In `data/surfaces.ini` of your track, change `SURFACE_0` to `CSPFACE_0`
+
+    :::caution ONLY CHANGE THE FIRST SURFACE IN THE FILE
+
+      Changing more than `SURFACE_0` will result in checksum errors for clients!
+
+    :::
+
+</TabItem>
+</Tabs>
+
+<details>
+<summary>**Where can I find CSP version IDs?**</summary>
+<p>
+
+In Content Manager, navigate to `Settings > Custom Shaders Patch > About & Updates` and look for the Currently active Shaders Patch version ID.
+
+![](./assets/lKOfMSR.png)
+
+If you need the ID of a version you currently don't have installed **[the official CSP Website](https://acstuff.ru/patch/)** lists the IDs in the `Other Versions` sections.
+
+![](./assets/Upd4ZJl.png)
+
+</p>
+</details>
+
+#### Adding CSP extra server options to the server {#extra-options-ini}
+Navigate to the `cfg` folder of the server and create a file called `csp_extra_options.ini`.  
+If you are hosting via Content Manager, click the `Folder` button at the bottom of the preset and create the file there instead.  
+
+[This CSP wiki page](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options) has a long list of options you can use.  
+The options on that page go into the `csp_extra_options.ini`, for example:
 
 ![](./assets/oxp4a21.png)    
-Place the file in the `cfg` folder of your server.  
-
-:::note
-
-If you're hosting the server via Content Manager, click the `Folder` button at the bottom of the preset and place it there instead.
-
-:::
 
 ### How do I allow driving the wrong way? {#wrong-way}
 
+This is also used to remove the incorrectly displayed wrong way indicator on track like Shutoko Revival Project.  
+If you want to make sure that people drive the correct way after adding this setting, use the [AutoModerationPlugin.](./plugins/AutoModerationPlugin.md)
+
 ```ini title="csp_extra_options.ini"
 [EXTRA_RULES]
-ALLOW_WRONG_WAY = 1 
+ALLOW_WRONG_WAY = 1   ; Allow cars to drive either way, gets rid of the wrong way sign on some tracks
 ```  
 If you get teleported back to pits, you may need to remove the `fast_lane.ai` for the track in your local game files.  
 By default: `C:\Program Files (x86)\Steam\steamapps\common\assettocorsa\content\tracks\<trackname>`.  
 
 ### How do I enable Teleportation? {#teleportation}
 
-For teleporting, three things have to be done:
+For teleporting, two things have to be done:
 
-- Requiring a minimum CSP version
 - Allowing cars in the entry list to teleport
 - Adding teleport destinations to the `csp_extra_options.ini`
 
 Depending on if you have the full version of Content Manager or not, there are two different ways to accomplish this:
 
-<Tabs>
+<Tabs groupId="content-manager">
 <TabItem value="content-manager" label="With Content Manager (Full Version)" default>
-
-  In the `Main` tab of your server check `Require CSP to Join` and enter the desired CSP version ID or click on `Autofill` to insert the version ID of the CSP version you have currently installed:  
-  ![](./assets/HxAVvsd.png)
 
   Check `Allow teleporting` for each car on your entry list:  
   ![](./assets/Il4RrjG.png)
@@ -188,17 +225,6 @@ Depending on if you have the full version of Content Manager or not, there are t
 
 </TabItem>
 <TabItem value="manual" label="Without Content Manager">
-
-  - In `content/tracks` of your server, create a new folder called `csp`
-  - Move your track folder into `content/tracks/csp`
-  - In `server_cfg.ini` change the path of your track like this: `TRACK=csp/<CSPversionID>/../<trackname>`, for example `TRACK=csp/2053/../shuto_revival_project_beta`
-  - In `data/surfaces.ini` of your track, change `SURFACE_0` to `CSPFACE_0`
-
-    :::caution ONLY CHANGE THE FIRST SURFACE IN THE FILE
-
-      Changing more than `SURFACE_0` will result in checksum errors for clients!
-
-    :::
 
   - In your `entry_list.ini` add a option to the end of each skin, for example `SKIN=<skinname>/ADAn`
 
@@ -224,7 +250,7 @@ If done correctly you should now have a `Teleport to...` option in the chat apps
 Either use the teleports used on the official SRP servers below or make some yourself.  
 
 <details>
-<summary>Official Shutoko Revival Project Teleport locations</summary>
+<summary>**Official Shutoko Revival Project Teleport locations**</summary>
 <p>Last updated: 2024-04-24</p>
 <p>
 
@@ -530,30 +556,39 @@ You can use the Objects Inspector or the [comfy map app](https://www.racedepartm
 The formating is as follows:
 
 ```ini
-POINT_0 = Name               ; destination name
-POINT_0_GROUP = Group Name   ; optional group
-POINT_0_POS = X, Y, Z        ; coordinates
-POINT_0_HEADING = 0          ; heading angle in degrees
+POINT_0 = Name               ; Destination name
+POINT_0_GROUP = Group Name   ; Optional group
+POINT_0_POS = X, Y, Z        ; Coordinates
+POINT_0_HEADING = 0          ; Heading angle in degrees
 ```
 
-**Having the comfy map app is not necessary to create points, enable or use teleportation!**
+:::note
+
+The comfy map app is not required to create points, enable or use teleportation!
+
+:::
 
 ### How do I enable Color Changing? {#color-changing}
 
 ```ini title="csp_extra_options.ini"
 [CUSTOM_COLOR]
-ALLOW_EVERYWHERE = 1
+ALLOW_EVERYWHERE = 1   ; Change car colors anywhere as long as the car is stopped.
 ```
 
-If AI cars are allowed to change their colors, they will spawn in random colors if possible.  
-**Keep in mind that you still need to allow cars to change colors via the `entry_list.ini` even if you're using `ALLOW_EVERYWHERE`.**
+If AI cars are allowed to change their colors, they will spawn in random colors if possible. 
+
+:::caution
+
+Every car still needs to be allowed to change colors via the `entry_list.ini`.
+
+:::
 
 ### How do I increase the speed in the pits? {#pit-speed-limiter}
 
 ```ini title="csp_extra_options.ini"
 [PITS_SPEED_LIMITER]
-KEEP_COLLISIONS = 0    ; will either activate or deactivate collisions between cars in the pits.
-SPEED_KMH = 80         ; the maximum speed allowed, the default is 80.
+KEEP_COLLISIONS = 0   ; Activate collisions between cars in pits
+SPEED_KMH = 80        ; Alter pits speed limiter value; default is 80
 ```
 
 [There are more options available here.](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Misc-%E2%80%93-Server-extra-options#pit-speed-limiter-settings)
@@ -573,7 +608,7 @@ You're going to need to host your script in plaintext somewhere publicly accessi
 
 ```ini title="csp_extra_options.ini"
 [SCRIPT_...]
-SCRIPT = "https://pastebin.com/raw/00000000000"    ; change this to the url of your script
+SCRIPT = "https://pastebin.com/raw/00000000000"    ; Change this to the url of your script
 ```
 
 [There are more options available here.](https://github.com/CheesyManiac/cheesy-lua/wiki/Extra-CSP-Server-Config-Values#server-scripts)
@@ -679,13 +714,3 @@ ServerDescription: |-
   - If you dont have Sol working, or are otherwise in doubt,
     keep your lights on.
 ```
-
-## Where can I find the CSP version IDs? {#csp-version-ids}
-
-The easiest way to get the ID for the CSP Version you're using is opening Content Manager and navigating to `Settings > Custom Shaders Patch > About & Updates` and then reading the Currently active Shaders Patch version ID.
-
-![](./assets/lKOfMSR.png)
-
-If you need the ID of a version you currently don't have installed [the official CSP Website](https://acstuff.ru/patch/) also has the IDs in the `Other Versions` sections.
-
-![](./assets/Upd4ZJl.png)

--- a/versioned_docs/version-0.0.54/faq.md
+++ b/versioned_docs/version-0.0.54/faq.md
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 ## Why can't I drive certain cars on my server? {#locked-cars}
 
 Certain car mods are designed to only be driven on servers that are whitelisted by the creators of the car mod.  
-Affected cars usually do not respond to the gas pedal input if they are used on other servers.
+Affected cars usually do not respond to the gas pedal input if they are used on other servers.  
 This restriction is built into the car mod itself and cannot be deactivated by any means.  
 Please note that these restrictions are not a feature of AssettoServer.
 

--- a/versioned_docs/version-0.0.54/thebeginnersguide.md
+++ b/versioned_docs/version-0.0.54/thebeginnersguide.md
@@ -344,7 +344,6 @@ Purchase Custom Shaders Patch previews on [x4fabs Patreon](https://www.patreon.c
 If we want to take advantage of some of the features that CSP provides for servers, we will need to make some changes and create a file inside our `cfg` folder.
 
 If you feel like you don't need a step-by-step explanation, read over the [FAQ section](./faq.md#csp-extra-options) that covers how to use them.  
-Skip to the `Without Content Manager` part of the [teleportation](./faq.md#teleportation) section if you do not want to repack the server and overwrite files you might have edited while following this guide.
 
 #### Requiring a minimum CSP Version {#requiring-csp-version}
 
@@ -358,7 +357,7 @@ Skip to the `Without Content Manager` part of the [teleportation](./faq.md#telep
     `TRACK=csp/<CSPversionID>/../<trackname>`, in this case `TRACK=csp/2144/../shuto_revival_project_beta`.
 
     The version ID `2144` will mean that in order to join the server, players will need to have **at least** CSP version 1.79 installed.  
-    If you want to require a different CSP version and don't know how where to get the ID from, read the [FAQ section](./faq.md#csp-version-ids) that explains it.
+    If you want to require a different CSP version and don't know how where to get the ID from, read this [FAQ section](./faq.md#requiring-csp-version).
 
 4.  Save and close the file and navigate to the `\content\tracks\csp\shuto_revival_project_beta\tatsumi_pa\data` folder of the server and open the `surfaces.ini`.  
     Change the name of the first surface from `SURFACE_0` to `CSPFACE_0`


### PR DESCRIPTION
43d0bbe: I decided to move around stuff inside the CSP extra option section because the requiring part was inside the teleport section. I also removed the csp version id section and moved it inside a drop down. Also added a bunch of clarifications.